### PR TITLE
Add difficulty scaling as the raid progresses

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -3,6 +3,9 @@
 
   "pmcDifficulty": 0.6,
   "scavDifficulty": 0.4,
+  "scavDifficultyMax": 0.8,
+  "scavDifficultyScalingFactor": 1,
+  "scavDifficultyScalingType": 0,
 
   "scavWaveDistribution": 0.5,
   "scavWaveQuantity": 1,

--- a/src/Spawning/buildScavMarksmanWaves.ts
+++ b/src/Spawning/buildScavMarksmanWaves.ts
@@ -26,6 +26,9 @@ export default function buildScavMarksmanWaves(
     maxBotPerZone,
     scavMaxGroupSize,
     scavDifficulty,
+    scavDifficultyMax,
+    scavDifficultyScalingType,
+    scavDifficultyScalingFactor,
     moreScavGroups,
   } = config;
 
@@ -161,6 +164,9 @@ export default function buildScavMarksmanWaves(
       0.5,
       WildSpawnType.MARKSMAN,
       0.5,
+      0.5,
+      0, // constant scaling factor
+      1,
       false,
       2,
       [],
@@ -187,6 +193,9 @@ export default function buildScavMarksmanWaves(
       scavWaveDistribution,
       WildSpawnType.ASSAULT,
       scavDifficulty,
+      scavDifficultyMax,
+      scavDifficultyScalingType,
+      scavDifficultyScalingFactor,
       false,
       scavMaxGroupSize,
       map === "gzHigh" ? [] : scavZones,

--- a/src/Spawning/utils.ts
+++ b/src/Spawning/utils.ts
@@ -106,6 +106,32 @@ export const getDifficulty = (diff: number) => {
   }
 };
 
+// Linearlly interpolates between a and b by t and clamps between the two values
+const lerp = (a: number, b: number, t: number) => {
+  let res = a + ((b - a) * t);
+  return res > b ? b : res < a ? a : res;
+};
+
+/**
+ * t = [0, 1]
+ * scaleType = {0, 1, 2}
+ * scaleFactor = (0, inf)
+ * diffMax = (diff, inf)
+ * */
+export const getDifficultyRamp = (diff: number, diffMax: number, scaleType: number, scaleFactor: number, t: number) => {
+  switch (scaleType) {
+    case 1: // linear
+        let linearDifficulty = lerp(diff, diffMax, scaleFactor * t);
+        return getDifficulty(linearDifficulty);
+    case 2: // exponential
+        let expDifficulty = lerp(diff, diffMax, scaleFactor * t * t);
+        return getDifficulty(expDifficulty);
+    case 0: // constant
+    default: // unknown value, default to constant
+        return getDifficulty(diff);
+  }
+};
+
 export const shuffle = <n>(array: any): n => {
   let currentIndex = array.length,
     randomIndex;

--- a/src/Spawning/utils.ts
+++ b/src/Spawning/utils.ts
@@ -14,6 +14,9 @@ export const waveBuilder = (
   waveDistribution: number,
   wildSpawnType: "marksman" | "assault",
   difficulty: number,
+  difficultyMax: number,
+  difficultyScalingType: number,
+  difficultyScalingFactor: number,
   isPlayer: boolean,
   maxSlots: number,
   combinedZones: string[] = [],
@@ -47,7 +50,8 @@ export const waveBuilder = (
     const max = !offset && waves.length < 1 ? 0 : timeStart + 10;
 
     if (waves.length >= 1 || offset) timeStart = timeStart + stage;
-    const BotPreset = getDifficulty(difficulty);
+    let time = timeStart / timeLimit; // Should be between [0, 1] with how far into the raid it is
+    const BotPreset = getDifficultyRamp(difficulty, difficultyMax, difficultyScalingType, difficultyScalingFactor, time);
     // console.log(wildSpawnType, BotPreset);
     // Math.round((1 - waves.length / totalWaves) * maxSlots) || 1;
     const slotMax =


### PR DESCRIPTION
This should add difficulty scaling as the raid progresses for only regular scavs. I'm not 100% certain if I'm getting the time in the raid properly (see: `Spawning/utils.ts:53`), but if you can get the time in raid right there it should ramp up difficulty based on the config.